### PR TITLE
Bug fix: Added support for Conditional Compilation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-gem "rails", "3.0.0.beta3"
+source :rubygems
+
+gem "rails", "3.0.0"
 
 group :test do
   gem "ruby-debug"

--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ Some cool things about Smurf, which also allude to the reasons I wrote it:
 * Other than installing it, you don't need to do anything
 * It just gets out of your way
 
-Smurf will work with most versions of Rails `2.3.x` and above; including Rails `3.0.0.beta1`.
+Smurf will work with most versions of Rails `2.3.x` and above; including Rails `3.0.0`.
 
 ### JSmin
 
@@ -29,6 +29,7 @@ The following are the rules I applied, gathered from various perusals around the
 5. Remove comments between `/* ... */` - this could be a problem (esp. for CSS hacks)
 6. Remove spaces around `;`, `:`, and `,` characters
 7. Ensure whitespace between closing brackets and periods
+8. Preserves [conditional comments](http://msdn.microsoft.com/en-us/library/121hztk3(VS.94).aspx) in IE (ex: /*@cc_on document.write("this will only write in IE") @*/)
 
 ## Installation
 
@@ -66,6 +67,6 @@ If you want to play around with different versions, you'll need to update the Ge
 
 Author: Justin Knowlden <gus@thumblemonks.com>
 
-Contributions from: Lance Ivy, Scott White, Daniel Schierbeck
+Contributions from: Lance Ivy, Scott White, Daniel Schierbeck, Paul Hepworth
 
 See MIT-LICENSE for licensing information

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.0.4.rails3.beta3
+1.0.4.rails3

--- a/lib/smurf/javascript.rb
+++ b/lib/smurf/javascript.rb
@@ -77,13 +77,14 @@ module Smurf
     end
 
     # Get the next character without getting it.
-    def peek()
-      lookaheadChar = @input.getc
-      @input.ungetc(lookaheadChar)
-      return lookaheadChar.chr
+    def peek(aheadCount=1)
+      history = []
+      aheadCount.times { history << @input.getc }
+      history.reverse.each { |chr| @input.ungetc(chr) }
+      return history.last.chr
     end
 
-    # mynext -- get the next character, excluding comments.
+    # mynext -- get the next character, excluding legitiment comments.
     # peek() is used to see if a '/' is followed by a '/' or '*'.
     def mynext()
       c = get
@@ -96,7 +97,7 @@ module Smurf
             end
           end
         end
-        if(peek == "*")
+        if(peek == "*" && peek(2) != "@") # not conditional comments
           get
           while(true)
             case get
@@ -151,7 +152,8 @@ module Smurf
                              @theA == "&" || @theA == "|" || @theA == "?" ||
                              @theA == "{" || @theA == "}" || @theA == ";" ||
                              @theA == "\n"))
-          @output.write @theA
+
+          @output.write(@theA) unless peek(2) == '@'
           @output.write @theB
           while (true)
             @theA = get

--- a/test/javascript_test.rb
+++ b/test/javascript_test.rb
@@ -28,4 +28,18 @@ context "Javascript minifier" do
       Smurf::Javascript.new(topic).minified
     end.equals("\nvar foo='bar   bar   baz';")
   end # working with multi-line strings
+
+  context "working with conditional compilation on IE" do
+    setup do
+      input = StringIO.new()
+      input.puts("/*@cc_on(function(){document.write('this will write out to IE browsers)});@*/")
+      input.rewind
+      input.read
+    end
+
+    should "not affect the string" do
+      Smurf::Javascript.new(topic).minified
+    end.equals("/*@cc_on(function(){document.write('this will write out to IE browsers)});@*/")
+  end # working with conditional compilation on IE
+
 end # Javascript minifier

--- a/test/rails/config/boot.rb
+++ b/test/rails/config/boot.rb
@@ -2,7 +2,7 @@ begin
   require File.expand_path("../../../../.bundle/environment", __FILE__)
 rescue LoadError
   require 'rubygems'
-  require 'bundler'
+  require 'bundler/setup'
   Bundler.setup :default
 end
 


### PR DESCRIPTION
Hi, thanks for writing this gem... been using it for ages but it wasn't until recently when I tried to bundle the html5shiv (http://code.google.com/p/html5shiv/) js into my js cache that I ran into a bug.

html5shiv is using conditional compilation for Internet Explorer and because it is a comment in most browsers the whole file is omitted from the cached bundle. Now, javascript files that contain this special "comment" will be preserved.

Source of the victim js can be seen here:
http://html5shiv.googlecode.com/svn/trunk/html5.js

I wrote a test for the main case and would love any feedback that you had for my contribution.

Thanks again for leading the charge with this very useful gem!

Cheers!
Paul
