### PR TITLE
Fixing single-line comments at EOF

### DIFF
--- a/lib/smurf/javascript.rb
+++ b/lib/smurf/javascript.rb
@@ -92,7 +92,7 @@ module Smurf
         if(peek == "/")
           while(true)
             c = get
-            if (c <= "\n")
+            if (c == -1 || c <= "\n")
             return c
             end
           end

--- a/test/javascript_test.rb
+++ b/test/javascript_test.rb
@@ -28,6 +28,19 @@ context "Javascript minifier" do
       Smurf::Javascript.new(topic).minified
     end.equals("\nvar foo='bar   bar   baz';")
   end # working with multi-line strings
+  
+  context "working with single-line comments without EOL." do
+    setup do
+      input = StringIO.new()
+      input.write("// I should not crash")
+      input.rewind
+      input.read
+    end
+
+    should "handle a single line comment at the end of the file without an EOL" do
+      Smurf::Javascript.new(topic).minified
+    end.equals("")
+  end
 
   context "working with conditional compilation on IE" do
     setup do


### PR DESCRIPTION
The JavaScript minifier shouldn't crash when a single line comment is present at the end of a file without an EOL character.

This fix prevents an # (ArgumentError) "comparison of Fixnum with String failed" error when a developer puts a single line comment at the end of a file without adding an EOL. 
